### PR TITLE
Two new functions for Sendinblue

### DIFF
--- a/src/adapters/Sendinblue.php
+++ b/src/adapters/Sendinblue.php
@@ -23,6 +23,8 @@ class Sendinblue extends BaseNewsletterAdapter
 {
     public $apiKey;
     public $listId;
+    public $doi;
+    public $doiId;
     private $_errorMessage;
     private $contactsApi;
 
@@ -44,7 +46,9 @@ class Sendinblue extends BaseNewsletterAdapter
             'class' => EnvAttributeParserBehavior::class,
             'attributes' => [
                 'apiKey',
-                'listId'
+                'listId',
+                'doi',
+                'doiId',
             ],
         ];
         return $behaviors;
@@ -58,6 +62,8 @@ class Sendinblue extends BaseNewsletterAdapter
         return [
             'apiKey' => Craft::t('newsletter', 'API Key'),
             'listId' => Craft::t('newsletter', 'Contact List ID'),
+            'doi' => Craft::t('newsletter', 'Send DOI mail to new subscribers'),
+            'doiId' => Craft::t('newsletter', 'DOI mail template ID'),
         ];
     }
 
@@ -125,7 +131,11 @@ class Sendinblue extends BaseNewsletterAdapter
             $contact = new CreateContact();
             $contact['email'] = $email;
             $contact['listIds'] = [$listId];
-            $clientContactApi->createContact($contact);
+            if ($this->doi) {
+                $clientContactApi->createDoiContact();
+            } else {
+                $clientContactApi->createContact($contact);
+            }
             return true;
         } catch (ApiException $apiException) {
             $this->_errorMessage = $this->_getErrorMessage($apiException);

--- a/src/templates/newsletterAdapters/Sendinblue/settings.twig
+++ b/src/templates/newsletterAdapters/Sendinblue/settings.twig
@@ -10,12 +10,37 @@
     errors: adapter.getErrors('apiKey')
 }) }}
 
-{{ forms.autosuggestField({
-    label: "Contact List ID"|t('newsletter'),
-    warning: "If left empty, users will not be associated with any specific list."|t('newsletter'),
-    id: 'listId',
-    name: 'listId',
-    suggestEnvVars: true,
-    value: adapter.listId,
-    errors: adapter.getErrors('listId')
+{{ forms.lightswitchField({
+    label: "Send DOI mail to subscriber"|t('newsletter'),
+    instructions: "If switched on, a DOI mail will be send using your DOI mail template in Sendinblue."|t('newsletter'),
+    id: 'doi',
+    name: 'doi',
+    on: adapter.doi,
+    errors: adapter.getErrors('doi'),
+    toggle: 'doi-settings',
+    reverseToggle: 'no-doi-settings'
 }) }}
+
+<div id="no-doi-settings"{% if adapter.doi %} class="hidden"{% endif %}>
+    {{ forms.autosuggestField({
+        label: "Contact List ID"|t('newsletter'),
+        warning: "If left empty, users will not be associated with any specific list."|t('newsletter'),
+        id: 'listId',
+        name: 'listId',
+        suggestEnvVars: true,
+        value: adapter.listId,
+        errors: adapter.getErrors('listId')
+    }) }}
+</div>
+
+<div id="doi-settings"{% if not adapter.doi %} class="hidden"{% endif %}>
+    {{ forms.autosuggestField({
+        label: "Contact List ID"|t('newsletter'),
+        required: true,
+        id: 'listId',
+        name: 'listId',
+        suggestEnvVars: true,
+        value: adapter.listId,
+        errors: adapter.getErrors('listId')
+    }) }}
+</div>

--- a/src/templates/newsletterAdapters/Sendinblue/settings.twig
+++ b/src/templates/newsletterAdapters/Sendinblue/settings.twig
@@ -11,6 +11,14 @@
 }) }}
 
 {{ forms.lightswitchField({
+    label: "Add subscriber to list when he already exists as contact"|t('newsletter'),
+    id: 'addIfExists',
+    name: 'addIfExists',
+    on: adapter.addIfExists,
+    errors: adapter.getErrors('addIfExists'),
+}) }}
+
+{{ forms.lightswitchField({
     label: "Send DOI mail to subscriber"|t('newsletter'),
     instructions: "If switched on, a DOI mail will be send using your DOI mail template in Sendinblue."|t('newsletter'),
     id: 'doi',
@@ -18,7 +26,7 @@
     on: adapter.doi,
     errors: adapter.getErrors('doi'),
     toggle: 'doi-settings',
-    reverseToggle: 'no-doi-settings'
+    reverseToggle: 'no-doi-settings',
 }) }}
 
 <div id="no-doi-settings"{% if adapter.doi %} class="hidden"{% endif %}>
@@ -36,11 +44,33 @@
 <div id="doi-settings"{% if not adapter.doi %} class="hidden"{% endif %}>
     {{ forms.autosuggestField({
         label: "Contact List ID"|t('newsletter'),
+        id: 'doiListId',
+        name: 'doiListId',
         required: true,
-        id: 'listId',
-        name: 'listId',
         suggestEnvVars: true,
-        value: adapter.listId,
-        errors: adapter.getErrors('listId')
+        value: adapter.doiListId,
+        errors: adapter.getErrors('doiListId')
+    }) }}
+
+    {{ forms.autosuggestField({
+        label: "DOI Mail Template ID"|t('newsletter'),
+        required: true,
+        id: 'doiTemplateId',
+        name: 'doiTemplateId',
+        suggestEnvVars: true,
+        value: adapter.doiTemplateId,
+        errors: adapter.getErrors('doiTemplateId')
+    }) }}
+
+    {{ forms.autosuggestField({
+        label: "Redirection URL"|t('newsletter'),
+        instructions: "URL of the web page that user will be redirected to after clicking on the double opt in URL."|t('newsletter'),
+        id: 'doiRedirectionUrl',
+        name: 'doiRedirectionUrl',
+        required: true,
+        suggestEnvVars: true,
+        suggestAliases: true,
+        value: adapter.doiRedirectionUrl,
+        errors: adapter.getErrors('doiRedirectionUrl')
     }) }}
 </div>


### PR DESCRIPTION
In this PR we added two new functions to the Sendinblue adapter:

- If a contact already exists in the Sendinblue account, you can now add the contact to the list given in the settings. There is a light switch in the settings to enable this.

- In some countries you have to send a DOI mail to the new subscriber. Sendinblue provides a special API call for this.