### PR TITLE
Make settings site specifc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes for Newsletter
 
+## Unreleased
+
+### Fixed
+
+- fix a bug in the Brevo adpater additional fields implementation that prevented subscriptions
+
+
 ## 3.0.0 - 2024-02-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add the ability to define per-site settings
+
 ### Fixed
 
 - fix a bug in the Brevo adpater additional fields implementation that prevented subscriptions

--- a/README.md
+++ b/README.md
@@ -132,16 +132,16 @@ You can use the following template as a starting point for your registration for
             <p>{{ 'Your newsletter subscription has been taken into account. Thank you.'|t }}</p>
         </div>
     {% endif %}
-    
+
     <form action="" method="post" accept-charset="UTF-8">
         {{ csrfInput() }}
-        
+
         {# Subscription process is handled by the newsletter plugin controller #}
         {{ actionInput('newsletter/newsletter/subscribe') }}
-        
+
         {# User will be redirected to the redirect input url upon successful subscription #}
         {{ redirectInput('thank-you') }}
-        
+
         <label for="newsletter-consent">
         	<input type="checkbox" value="check" name="consent" id="newsletter-consent" required {% if newsletterForm.hasErrors('consent') %}aria-invalid="true" aria-describedby="consent-error"{% endif %}>
             {{'I agree to receive your emails and confirm that I have read your privacy policy.'|t}}
@@ -149,7 +149,7 @@ You can use the following template as a starting point for your registration for
         {% if newsletterForm.hasErrors('consent') %}
             <div id="consent-error" role="alert" class="text-sm text-error font-bold">{{ newsletterForm.getFirstError('consent') }}</div>
         {% endif %}
-        
+
         <label for="newsletter-email">{{ 'Votre email'|t }}<span aria-hidden="true">*</span></label>
         <input id="newsletter-email" required name="email" type="email" placeholder="j.dupont@gmail.com" value="{{ newsletterForm.email }}" {% if newsletterForm.hasErrors('email') %}aria-invalid="true" aria-describedby="email-error"{% endif %}>
 
@@ -162,11 +162,11 @@ You can use the following template as a starting point for your registration for
         <label for="newsletter-lastname">{{ 'Lastname'|t }}</label>
         <input id="newsletter-lastname" name="additionalFields[lastname]" type="text"
            value="{{ newsletterForm.additionalFields.lastname ?? '' }}">
-           
+
         {% if newsletterForm.hasErrors('email') %}
             <div id="email-error" role="alert" class="text-sm text-error font-bold">{{ newsletterForm.getFirstError('email') }}</div>
         {% endif %}
-        
+
         <button type="submit">{{ 'Subscribe'|t }}</button>
 
     </form>
@@ -187,10 +187,10 @@ For example, to provide a `firstname` field, input should be named `additionalFi
 
 ## XHR / AJAX form
 
-Alternatively, you can submit the newsletter form with Javascript.   
+Alternatively, you can submit the newsletter form with Javascript.
 This gives you more freedom to provide visual effects to the user and prevents the page from reloading and scrolling to
-the top of the page.  
-The downside is that you need to write the ajax-request.  
+the top of the page.
+The downside is that you need to write the ajax-request.
 Use the example below as a reference, note the required `application/json` header:
 
 ```javascript
@@ -215,6 +215,30 @@ xhr.send(data);
 > ⚠️ If the Google reCAPTCHA verification is enabled, add the `data.append("g-recaptcha-response", "");` to the request
 > as well!
 
+## Events
+
+### `NewsletterForm::EVENT_BEFORE_SUBSCRIBE`
+
+This event is triggered after validating the NewsletterForm model but before actually subscribing. You can cancel the
+subscription by setting its `isSpam` property to `true`. When this happens, the response sent to the client indicates
+that the subscription was successful but actually nothing was sent to the adapters. This filters out spambots without
+letting them know they were filtered.
+
+Example:
+
+```php
+Event::on(
+    NewsletterForm::class,
+    NewsletterForm::EVENT_BEFORE_SUBSCRIBE,
+    function (SubscribeEvent $event) {
+	    $isSpam = // custom spam detection logic...
+        if ($isSpam) {
+            $event->isSpam = true;
+        }
+    }
+);
+```
+
 ## Custom validations
 
 You can provide your own validations on frontend form submission in a project module or a plugin using
@@ -228,7 +252,7 @@ Event::on(
 	NewsletterForm::class,
 	NewsletterForm::EVENT_AFTER_VALIDATE,
 	static function (Event $event) {
-	    $form = $event->sender;	    
+	    $form = $event->sender;
 	    $isSpam = // custom spam detection logic...
 	    if($isSpam) {
 	    	$this->addError('email', 'Spam detected!');
@@ -257,7 +281,7 @@ class MySuperNewsletterAdapter extends BaseNewsletterAdapter
     public $apiKey;
     // Store any error occurring in the subscribe method here
     private $_errorMessage;
-    
+
     /**
      * @inheritdoc
      */
@@ -293,7 +317,7 @@ class MySuperNewsletterAdapter extends BaseNewsletterAdapter
             'adapter' => $this
         ]);
 	    }
-	
+
 	/**
 	 * Try to subscribe the given email into the newsletter mailing list service
 	 * @param string $email

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,6 @@ includes:
     - vendor/craftcms/phpstan/phpstan.neon
 
 parameters:
-    level: 5
+    level: 6
     paths:
         - src

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
+use Rector\CodingStyle\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\SetList;
 
@@ -16,7 +18,8 @@ return RectorConfig::configure()
             __DIR__ . '/tests/_output',
             __DIR__ . '/tests/_support',
             __DIR__ . '/src/translations',
-
+            EncapsedStringsToSprintfRector::class,
+            WrapEncapsedVariableInCurlyBracesRector::class,
         ]
     )
     ->withPhpSets(php80: true)

--- a/rector.php
+++ b/rector.php
@@ -26,5 +26,6 @@ return RectorConfig::configure()
     ->withSets([
         SetList::CODE_QUALITY,
         SetList::CODING_STYLE,
-        SetList::EARLY_RETURN
+        SetList::EARLY_RETURN,
+        SetList::TYPE_DECLARATION,
     ]);

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -83,7 +83,7 @@ class Newsletter extends Plugin
     /**
      * Initializes the plugin.
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
         self::$plugin = $this;

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -98,10 +98,12 @@ class Newsletter extends Plugin
         $this->set('newsletterAdapterService', NewsletterAdapterService::class);
         // Register adapter component
         // TODO: rename to currentSiteNewsletterAdapter
-        $this->set('adapter', function() {
-            $currentSite = Craft::$app->getSites()->getCurrentSite();
-            return $this->getNewsletterAdapterForSite($currentSite->handle);
-        });
+        $this->set(
+            'adapter',
+            fn(): NewsletterAdapterInterface => $this->getNewsletterAdapterForSite(
+                Craft::$app->getSites()->getCurrentSite()->handle,
+            ),
+        );
 
         Craft::info(
             Craft::t(
@@ -122,7 +124,7 @@ class Newsletter extends Plugin
         Event::on(
             Plugins::class,
             Plugins::EVENT_AFTER_INSTALL_PLUGIN,
-            function(PluginEvent $event) {
+            function(PluginEvent $event): void {
                 if ($event->plugin !== $this) {
                     return;
                 }
@@ -157,7 +159,7 @@ class Newsletter extends Plugin
         Event::on(
             NewsletterForm::class,
             NewsletterForm::EVENT_AFTER_VALIDATE,
-            static function(Event $event) {
+            static function(Event $event): void {
                 $form = $event->sender;
                 if (!GoogleRecaptcha::$plugin->recaptcha->verify()) {
                     $form->addError('recaptcha', Craft::t('newsletter', 'Please prove you are not a robot.'));
@@ -246,7 +248,7 @@ class Newsletter extends Plugin
             'plugin' => $this,
             'configPath' => $configPath ?? null,
             'sites' => $sites,
-            'tabs' => ArrayHelper::map($sites, 'handle', static fn($site) => [
+            'tabs' => ArrayHelper::map($sites, 'handle', static fn($site): array => [
                 'url'   => "#$site->handle",
                 'label' => $site->name,
             ]),
@@ -273,7 +275,7 @@ class Newsletter extends Plugin
 
     private function _registerVariables(): void
     {
-        Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function(Event $e) {
+        Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function(Event $e): void {
             $e->sender->set('newsletter', NewsletterVariable::class);
         });
     }

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -38,11 +38,6 @@ use yii\web\Response;
  *
  * @property NewsletterAdapterInterface $adapter
  * @property NewsletterAdapterService $newsletterAdapterService
- *
- * @author    juban
- * @package   Newsletter
- * @since     1.0.0
- *
  * @property  LocalizedSettingsCollection $settings
  * @method    LocalizedSettingsCollection getSettings()
  */

--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -3,22 +3,28 @@
 namespace juban\newsletter;
 
 use Craft;
+use craft\base\Model;
 use craft\base\Plugin;
 use craft\events\PluginEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\helpers\App;
 use craft\helpers\ArrayHelper;
-use craft\helpers\Component;
 use craft\helpers\UrlHelper;
 use craft\services\Plugins;
+use craft\web\Controller;
+use craft\web\twig\variables\CraftVariable;
 use juban\googlerecaptcha\GoogleRecaptcha;
 use juban\newsletter\adapters\Brevo;
 use juban\newsletter\adapters\Mailchimp;
 use juban\newsletter\adapters\Mailjet;
 use juban\newsletter\adapters\NewsletterAdapterInterface;
+use juban\newsletter\models\LocalizedSettingsCollection;
 use juban\newsletter\models\NewsletterForm;
 use juban\newsletter\models\Settings;
+use juban\newsletter\services\NewsletterAdapterService;
+use juban\newsletter\variables\Newsletter as NewsletterVariable;
 use yii\base\Event;
+use yii\web\Response;
 
 /**
  * Craft plugins are very much like little applications in and of themselves. We’ve made
@@ -31,13 +37,14 @@ use yii\base\Event;
  * https://docs.craftcms.com/v3/extend/
  *
  * @property NewsletterAdapterInterface $adapter
+ * @property NewsletterAdapterService $newsletterAdapterService
  *
  * @author    juban
  * @package   Newsletter
  * @since     1.0.0
  *
- * @property  Settings $settings
- * @method    Settings getSettings()
+ * @property  LocalizedSettingsCollection $settings
+ * @method    LocalizedSettingsCollection getSettings()
  */
 class Newsletter extends Plugin
 {
@@ -91,21 +98,14 @@ class Newsletter extends Plugin
 
         $this->_registerAfterInstallEvent();
         $this->_registerRecaptchaVerification();
+        $this->_registerVariables();
 
+        $this->set('newsletterAdapterService', NewsletterAdapterService::class);
         // Register adapter component
+        // TODO: rename to currentSiteNewsletterAdapter
         $this->set('adapter', function() {
-            $adapterTypes = self::getAdaptersTypes();
-            // Backward compatibility with legacy adapters
-            if (str_starts_with($this->settings->adapterType, "simplonprod")) {
-                $this->settings->adapterType = str_replace('simplonprod', 'juban', $this->settings->adapterType);
-            }
-
-            if ($this->settings->adapterType === null) {
-                $this->settings->adapterType = $adapterTypes[0];
-                $this->settings->adapterTypeSettings = [];
-            }
-
-            return self::createAdapter($this->settings->adapterType, $this->settings->adapterTypeSettings);
+            $currentSite = Craft::$app->getSites()->getCurrentSite();
+            return $this->getNewsletterAdapterForSite($currentSite->handle);
         });
 
         Craft::info(
@@ -149,7 +149,9 @@ class Newsletter extends Plugin
      */
     private function _registerRecaptchaVerification(): void
     {
-        if (App::parseBooleanEnv(Newsletter::$plugin->settings->recaptchaEnabled) !== true) {
+        $settings = $this->getCurrentSiteSettings();
+
+        if (App::parseBooleanEnv($settings->recaptchaEnabled) !== true) {
             return;
         }
 
@@ -172,6 +174,7 @@ class Newsletter extends Plugin
     /**
      * Return the list of available newsletter adapters
      * @return string[]
+     * FIXME: Move this method to the NewsletterAdapterService
      */
     public static function getAdaptersTypes(): array
     {
@@ -189,80 +192,51 @@ class Newsletter extends Plugin
         return $event->types;
     }
 
-    // Protected Methods
-    // =========================================================================
-    /**
-     * @param array|null $settings
-     * @return \craft\base\ComponentInterface
-     * @throws \craft\errors\MissingComponentException
-     * @throws \yii\base\InvalidConfigException
-     */
-    public static function createAdapter(string $type, array $settings = null): \craft\base\ComponentInterface
-    {
-        return Component::createComponent([
-            'type' => $type,
-            'settings' => $settings,
-        ], NewsletterAdapterInterface::class);
-    }
-
     public function beforeSaveSettings(): bool
     {
-        if (Craft::$app->request->isPost) {
-            $postSettings = Craft::$app->request->post('settings');
-            if (isset($postSettings['adapterType'])) {
-                $adapterSettings = $postSettings['adapterSettings'][$postSettings['adapterType']] ?? [];
-                $adapter = self::createAdapter($postSettings['adapterType'], $adapterSettings);
-                if (!$adapter->validate()) {
-                    return false;
-                }
+        $settings = $this->getSettings();
 
-                $this->settings->adapterTypeSettings = $adapter->getAttributes();
+        // Convert SiteSettings objects into arrays before saving
+        $convertedSites = [];
+        foreach ($settings->localizedSettings as $siteHandle => $siteSettings) {
+            if ($siteSettings instanceof Settings) {
+                $convertedSites[$siteHandle] = $siteSettings->toArray();
             } else {
-                return false;
+                $convertedSites[$siteHandle] = $siteSettings;
             }
         }
 
-        return true;
+        // Update the settings model with the converted site settings
+        $settings->localizedSettings = $convertedSites;
+
+        return parent::beforeSaveSettings();
     }
 
-    /**
-     * Creates and returns the model used to store the plugin’s settings.
-     *
-     * @return Settings|null
-     */
-    protected function createSettingsModel(): ?\craft\base\Model
+    protected function createSettingsModel(): ?Model
     {
-        return new Settings();
+        return new LocalizedSettingsCollection();
     }
 
-    /**
-     * Returns the rendered settings HTML, which will be inserted into the content
-     * block on the settings page.
-     *
-     * @return string The rendered settings HTML
-     */
-    protected function settingsHtml(): ?string
+    public function getSettingsResponse(): Response
     {
-        $allAdapterTypes = self::getAdaptersTypes();
-        $allAdapters = [];
-        $adapterTypeOptions = [];
-        $adapter = null;
-
-        if (Craft::$app->request->post('settings')) {
-            $postSettings = Craft::$app->request->post('settings');
-            $adapterSettings = $postSettings['adapterSettings'][$postSettings['adapterType']] ?? [];
-            $adapter = self::createAdapter($postSettings['adapterType'], $adapterSettings);
-            $adapter->validate();
+        // check if a configuration file may override Control Panel settings
+        $configService = Craft::$app->getConfig();
+        $config = $configService->getConfigFromFile('newsletter');
+        if (!empty($config)) {
+            $configPath = $configService->getConfigFilePath('newsletter');
         }
 
-        if (!$adapter instanceof \craft\base\ComponentInterface) {
-            $adapter = $this->adapter;
-        }
+        $sites = Craft::$app->getSites()->getEditableSites();
+
+        /** @var Controller $controller */
+        $controller = Craft::$app->controller;
 
         // Create every available adapter
-        foreach ($allAdapterTypes as $adapterType) {
+        $allAdapters = [];
+        $adapterTypeOptions = [];
+        foreach (self::getAdaptersTypes() as $adapterType) {
             /** @var string|NewsletterAdapterInterface $adapterType */
-            $allAdapters[] = self::createAdapter($adapterType);
+            $allAdapters[] = $this->newsletterAdapterService->createAdapter($adapterType);
             $adapterTypeOptions[] = [
                 'value' => $adapterType,
                 'label' => $adapterType::displayName(),
@@ -272,22 +246,40 @@ class Newsletter extends Plugin
         // Sort them by name
         ArrayHelper::multisort($adapterTypeOptions, 'label');
 
-        // check if a configuration file may override Control Panel settings
-        $configService = Craft::$app->getConfig();
-        $config = $configService->getConfigFromFile('newsletter');
-        if (!empty($config)) {
-            $configPath = $configService->getConfigFilePath('newsletter');
-        }
+        return $controller->renderTemplate('newsletter/_layouts/settings.twig', [
+            // for _layout/settings.twig
+            'plugin' => $this,
+            'configPath' => $configPath ?? null,
+            'sites' => $sites,
+            'tabs' => ArrayHelper::map($sites, 'handle', static fn($site) => [
+                'url'   => "#$site->handle",
+                'label' => $site->name,
+            ]),
 
-        return Craft::$app->view->renderTemplate(
-            'newsletter/settings',
-            [
-                'settings' => $this->getSettings(),
-                'allAdapters' => $allAdapters,
-                'adapterTypeOptions' => $adapterTypeOptions,
-                'adapter' => $adapter,
-                'configPath' => $configPath ?? null,
-            ]
-        );
+            // for site-settings.twig
+            'settings' => $this->getSettings(),
+            'allAdapters' => $allAdapters,
+            'adapterTypeOptions' => $adapterTypeOptions,
+        ]);
+    }
+
+    public function getCurrentSiteSettings(): ?Settings
+    {
+        $currentSiteHandle = Craft::$app->getSites()->getCurrentSite()->handle;
+
+        return $this->getSettings()->getSiteSettings($currentSiteHandle);
+
+    }
+
+    public function getNewsletterAdapterForSite(string $siteHandle): NewsletterAdapterInterface
+    {
+        return $this->newsletterAdapterService->getNewsletterAdapterForSite($siteHandle);
+    }
+
+    private function _registerVariables(): void
+    {
+        Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function(Event $e) {
+            $e->sender->set('newsletter', NewsletterVariable::class);
+        });
     }
 }

--- a/src/adapters/BaseNewsletterAdapter.php
+++ b/src/adapters/BaseNewsletterAdapter.php
@@ -4,11 +4,6 @@ namespace juban\newsletter\adapters;
 
 use craft\base\ConfigurableComponent;
 
-/**
- * BaseNewsletterAdapter class
- *
- * @author juban
- **/
 abstract class BaseNewsletterAdapter extends ConfigurableComponent implements NewsletterAdapterInterface
 {
 }

--- a/src/adapters/Brevo.php
+++ b/src/adapters/Brevo.php
@@ -118,7 +118,7 @@ class Brevo extends BaseNewsletterAdapter
 
     public function getClientContactApi(): ContactsApi
     {
-        if (!$this->_contactsApi) {
+        if (!$this->_contactsApi instanceof ContactsApi) {
             $config = Configuration::getDefaultConfiguration()->setApiKey('api-key', App::parseEnv($this->apiKey));
 
             $this->_contactsApi = new ContactsApi(

--- a/src/adapters/Brevo.php
+++ b/src/adapters/Brevo.php
@@ -148,7 +148,7 @@ class Brevo extends BaseNewsletterAdapter
             if (App::parseBooleanEnv($this->doi)) {
                 $contact = new CreateDoiContact([
                     'email' => $email,
-                    'attributes' => $attributes,
+                    'attributes' => (object)$attributes,
                     'includeListIds' => [$listId],
                     'templateId' => (int)App::parseEnv($this->doiTemplateId),
                     'redirectionUrl' => App::parseEnv($this->doiRedirectionUrl),
@@ -157,7 +157,7 @@ class Brevo extends BaseNewsletterAdapter
             } else {
                 $contact = new CreateContact([
                     'email' => $email,
-                    'attributes' => $attributes,
+                    'attributes' => (object)$attributes,
                     'listIds' => [$listId],
                 ]);
                 $clientContactApi->createContact($contact);
@@ -173,7 +173,7 @@ class Brevo extends BaseNewsletterAdapter
     private function _registerContact(string $email, ContactsApi $clientContactApi, array $attributes = null): bool
     {
         try {
-            $contact = new CreateContact(['email' => $email, 'attributes' => $attributes]);
+            $contact = new CreateContact(['email' => $email, 'attributes' => (object)$attributes]);
             $clientContactApi->createContact($contact);
             return true;
         } catch (ApiException $apiException) {
@@ -185,7 +185,7 @@ class Brevo extends BaseNewsletterAdapter
     private function _addContactToList(string $email, int $listId, ContactsApi $clientContactApi, array $attributes = null): bool
     {
         try {
-            $contact = new UpdateContact(['listIds' => [$listId], 'attributes' => $attributes]);
+            $contact = new UpdateContact(['listIds' => [$listId], 'attributes' => (object)$attributes]);
             $clientContactApi->updateContact($email, $contact);
             return true;
         } catch (ApiException $apiException) {

--- a/src/adapters/Brevo.php
+++ b/src/adapters/Brevo.php
@@ -13,29 +13,31 @@ use Craft;
 use craft\behaviors\EnvAttributeParserBehavior;
 use craft\helpers\App;
 use GuzzleHttp\Client;
+use Throwable;
+use yii\base\Behavior;
 use yii\helpers\VarDumper;
 
 /**
- *
- * @property-read ContactsApi $clientContactApi
- * @property-read mixed $settingsHtml
- * @property-read null|string $subscriptionError
+ * @property ContactsApi $clientContactApi
+ * @property-read ?string $settingsHtml
+ * @property-read ?string $subscriptionError
+ * @phpstan-type attributesType array<string, mixed>
  */
 class Brevo extends BaseNewsletterAdapter
 {
-    public $apiKey;
+    public ?string $apiKey = null;
 
-    public $listId;
+    public ?string $listId = null;
 
-    public $doi = false;
+    public bool $doi = false;
 
-    public $doiTemplateId;
+    public ?string $doiTemplateId = null;
 
-    public $doiRedirectionUrl;
+    public ?string $doiRedirectionUrl = null;
 
-    private $_errorMessage;
+    private ?string $_errorMessage = null;
 
-    private $_contactsApi;
+    private ?ContactsApi $_contactsApi = null;
 
     /**
      * @inheritdoc
@@ -47,6 +49,7 @@ class Brevo extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<string, array{class: class-string}|class-string|Behavior>
      */
     public function behaviors(): array
     {
@@ -66,6 +69,7 @@ class Brevo extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<string, string>
      */
     public function attributeLabels(): array
     {
@@ -80,6 +84,7 @@ class Brevo extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @throws Throwable If rendering the template fails
      */
     public function getSettingsHtml(): ?string
     {
@@ -88,6 +93,9 @@ class Brevo extends BaseNewsletterAdapter
         ]);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function subscribe(string $email, array $additionalFields = null): bool
     {
         $clientContactApi = $this->getClientContactApi();
@@ -122,6 +130,9 @@ class Brevo extends BaseNewsletterAdapter
         return $this->_contactsApi;
     }
 
+    /**
+     * @noinspection PhpUnused Called by Yii when setting the virtual property $this->client
+     */
     public function setClientContactApi(ContactsApi $contactsApi): void
     {
         $this->_contactsApi = $contactsApi;
@@ -138,6 +149,9 @@ class Brevo extends BaseNewsletterAdapter
         }
     }
 
+    /**
+     * @param attributesType $attributes
+     */
     private function _registerContactToList(
         string $email,
         int $listId,
@@ -170,6 +184,9 @@ class Brevo extends BaseNewsletterAdapter
         }
     }
 
+    /**
+     * @param attributesType $attributes
+     */
     private function _registerContact(string $email, ContactsApi $clientContactApi, array $attributes = null): bool
     {
         try {
@@ -182,6 +199,9 @@ class Brevo extends BaseNewsletterAdapter
         }
     }
 
+    /**
+     * @param attributesType $attributes
+     */
     private function _addContactToList(string $email, int $listId, ContactsApi $clientContactApi, array $attributes = null): bool
     {
         try {
@@ -223,6 +243,8 @@ class Brevo extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<mixed>
+     * @noinspection PhpPluralMixedCanBeReplacedWithArrayInspection Yii rules are too polymorphic to be described easily
      */
     protected function defineRules(): array
     {

--- a/src/adapters/Dummy.php
+++ b/src/adapters/Dummy.php
@@ -3,15 +3,19 @@
 namespace juban\newsletter\adapters;
 
 use Craft;
+use Throwable;
 
 /**
- * Dummy class
+ * Dummy adapter
  * This class is intended as a base for concret adapters
  *
+ * @property-read ?string $settingsHtml
+ * @property-read string $subscriptionError
  */
 class Dummy extends BaseNewsletterAdapter
 {
-    public $someAttribute;
+    /** @noinspection PhpUnused */
+    public mixed $someAttribute = null;
 
     /**
      * @inheritdoc
@@ -23,6 +27,7 @@ class Dummy extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<string, string>
      */
     public function attributeLabels(): array
     {
@@ -33,6 +38,7 @@ class Dummy extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @throws Throwable If rendering the template fails
      */
     public function getSettingsHtml(): ?string
     {
@@ -41,18 +47,11 @@ class Dummy extends BaseNewsletterAdapter
         ]);
     }
 
-    /**
-     * @param string $email
-     * @return bool
-     */
     public function subscribe(string $email, array $additionalFields = null): bool
     {
         return true;
     }
 
-    /**
-     * @return string
-     */
     public function getSubscriptionError(): string
     {
         return "Some error";
@@ -60,6 +59,8 @@ class Dummy extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<mixed>
+     * @noinspection PhpPluralMixedCanBeReplacedWithArrayInspection Yii rules are too polymorphic to be described easily
      */
     protected function defineRules(): array
     {

--- a/src/adapters/Dummy.php
+++ b/src/adapters/Dummy.php
@@ -8,8 +8,7 @@ use Craft;
  * Dummy class
  * This class is intended as a base for concret adapters
  *
- * @author juban
- **/
+ */
 class Dummy extends BaseNewsletterAdapter
 {
     public $someAttribute;

--- a/src/adapters/Mailchimp.php
+++ b/src/adapters/Mailchimp.php
@@ -9,22 +9,32 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
 use MailchimpMarketing\Api\ListsApi;
 use MailchimpMarketing\ApiClient;
+use Throwable;
+use yii\base\Behavior;
 use yii\helpers\Json;
 use yii\helpers\VarDumper;
 
+/**
+ * @phpstan-type AdditionalFieldsType array<string, mixed>
+ * @property-read null|string $subscriptionError
+ * @property-read null|string $settingsHtml
+ * @property ListsApi $listApi
+ * @property ApiClient $apiClient
+ * @property ?ApiClient $client
+ */
 class Mailchimp extends BaseNewsletterAdapter
 {
-    public $apiKey;
+    public ?string $apiKey = null;
 
-    public $serverPrefix;
+    public ?string $serverPrefix = null;
 
-    public $listId;
+    public ?string $listId = null;
 
-    private $_errorMessage;
+    private ?string $_errorMessage = null;
 
-    private $_client;
+    private ?ApiClient $_client = null;
 
-    private $_listApi;
+    private ?ListsApi $_listApi = null;
 
     /**
      * @inheritdoc
@@ -36,6 +46,7 @@ class Mailchimp extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<string, array{class: class-string}|class-string|Behavior>
      */
     public function behaviors(): array
     {
@@ -53,6 +64,7 @@ class Mailchimp extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @throws Throwable If rendering the template fails
      */
     public function getSettingsHtml(): ?string
     {
@@ -95,11 +107,17 @@ class Mailchimp extends BaseNewsletterAdapter
         return $this->_listApi;
     }
 
+    /**
+     * @noinspection PhpUnused Called by Yii when setting the virtual property $this->listApi
+     */
     public function setListApi(ListsApi $listsApi): void
     {
         $this->_listApi = $listsApi;
     }
 
+    /**
+     * @param AdditionalFieldsType $additionalFields
+     */
     private function _registerContact(
         string $email,
         ListsApi $listsApi,
@@ -117,11 +135,11 @@ class Mailchimp extends BaseNewsletterAdapter
 
             return true;
         } catch (ClientException $clientException) {
-            $response = Json::decode($clientException->getResponse()->getBody()->getContents(), true);
+            $response = Json::decode($clientException->getResponse()->getBody()->getContents());
             $status = $response['status'] ?? 400;
             $title = $response['title'] ?? '';
             if ($status === 400 && $title === 'Forgotten Email Not Subscribed') {
-                // Contact was permanently deleted from list,
+                // Contact was permanently deleted from the list,
                 // consider him as already subscribed to prevent email enumeration
                 return true;
             }
@@ -183,6 +201,9 @@ class Mailchimp extends BaseNewsletterAdapter
         return $errorMessage;
     }
 
+    /**
+     * @noinspection PhpUnused Called by Yii when setting the virtual property $this->client
+     */
     public function setApiClient(ApiClient $client): void
     {
         $this->_client = $client;
@@ -195,6 +216,8 @@ class Mailchimp extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<mixed>
+     * @noinspection PhpPluralMixedCanBeReplacedWithArrayInspection Yii rules are too polymorphic to be described easily
      */
     protected function defineRules(): array
     {

--- a/src/adapters/Mailjet.php
+++ b/src/adapters/Mailjet.php
@@ -10,11 +10,6 @@ use Mailjet\Resources;
 use Mailjet\Response;
 use yii\helpers\VarDumper;
 
-/**
- * Mailjet class
- *
- * @author juban
- **/
 class Mailjet extends BaseNewsletterAdapter
 {
     public $apiKey;

--- a/src/adapters/Mailjet.php
+++ b/src/adapters/Mailjet.php
@@ -188,7 +188,7 @@ class Mailjet extends BaseNewsletterAdapter
     private function _updateContactData(Client $client, int $contactId, array $data): bool
     {
         $body = array_map(
-            static fn($key, $value) => ['Name' => $key, 'Value' => $value],
+            static fn($key, $value): array => ['Name' => $key, 'Value' => $value],
             array_keys($data),
             array_values($data)
         );

--- a/src/adapters/Mailjet.php
+++ b/src/adapters/Mailjet.php
@@ -8,19 +8,27 @@ use craft\helpers\App;
 use Mailjet\Client;
 use Mailjet\Resources;
 use Mailjet\Response;
+use Throwable;
+use yii\base\Behavior;
 use yii\helpers\VarDumper;
 
+/**
+ *
+ * @property-read Client $client
+ * @property-read ?string $settingsHtml
+ * @property-read ?string $subscriptionError
+ */
 class Mailjet extends BaseNewsletterAdapter
 {
-    public $apiKey;
+    public ?string $apiKey = null;
 
-    public $apiSecret;
+    public ?string $apiSecret = null;
 
-    public $listId;
+    public ?string $listId = null;
 
-    private $_client;
+    private ?Client $_client = null;
 
-    private $_errorMessage;
+    private ?string $_errorMessage = null;
 
     /**
      * @inheritdoc
@@ -32,6 +40,7 @@ class Mailjet extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<string, array{class: class-string}|class-string|Behavior>
      */
     public function behaviors(): array
     {
@@ -49,6 +58,7 @@ class Mailjet extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<string, string>
      */
     public function attributeLabels(): array
     {
@@ -61,6 +71,7 @@ class Mailjet extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @throws Throwable If rendering the template fails
      */
     public function getSettingsHtml(): ?string
     {
@@ -112,9 +123,6 @@ class Mailjet extends BaseNewsletterAdapter
         return $this->_client;
     }
 
-    /**
-     * @return int|null
-     */
     private function _getContactId(Client $client, string $email): ?int
     {
         $response = $client->get(Resources::$Contact, ['id' => $email]);
@@ -125,9 +133,6 @@ class Mailjet extends BaseNewsletterAdapter
         return null;
     }
 
-    /**
-     * @return int|null
-     */
     private function _registerContact(Client $client, string $email): ?int
     {
         $body = [
@@ -144,9 +149,6 @@ class Mailjet extends BaseNewsletterAdapter
         return $response->getData()[0]['ID'] ?? null;
     }
 
-    /**
-     * @return string
-     */
     private function _getErrorMessageFromRessource(Response $response): string
     {
         $errorLogMessages = [
@@ -181,13 +183,15 @@ class Mailjet extends BaseNewsletterAdapter
     }
 
     /**
-     * @return bool
+     * @param array<string, mixed> $data
      */
     private function _updateContactData(Client $client, int $contactId, array $data): bool
     {
-        $body = array_map(static fn($key, $value) => ['Name' => $key, 'Value' => $value],
+        $body = array_map(
+            static fn($key, $value) => ['Name' => $key, 'Value' => $value],
             array_keys($data),
-            array_values($data));
+            array_values($data)
+        );
         $response = $client->put(Resources::$Contactdata, ['id' => $contactId, 'body' => ['Data' => $body]]);
         if (!$response->success()) {
             $this->_errorMessage = $this->_getErrorMessageFromRessource($response);
@@ -196,9 +200,6 @@ class Mailjet extends BaseNewsletterAdapter
         return $response->success();
     }
 
-    /**
-     * @return bool
-     */
     private function _subscribeContactToList(Client $client, string $email): bool
     {
         // Register contact to list
@@ -228,6 +229,8 @@ class Mailjet extends BaseNewsletterAdapter
 
     /**
      * @inheritdoc
+     * @return array<mixed>
+     * @noinspection PhpPluralMixedCanBeReplacedWithArrayInspection Yii rules are too polymorphic to be described easily
      */
     protected function defineRules(): array
     {

--- a/src/adapters/NewsletterAdapterInterface.php
+++ b/src/adapters/NewsletterAdapterInterface.php
@@ -8,14 +8,12 @@ interface NewsletterAdapterInterface extends ConfigurableComponentInterface
 {
     /**
      * Try to subscribe the given email into the newsletter mailing list service
-     * @param array|null $additionalFields
-     * @return bool
+     * @param array<string, mixed>|null $additionalFields
      */
-    public function subscribe(string $email, array $additionalFields = null);
+    public function subscribe(string $email, array $additionalFields = null): bool;
 
     /**
      * Return the latest error message after a call to the subscribe method
-     * @return null|string
      */
-    public function getSubscriptionError();
+    public function getSubscriptionError(): ?string;
 }

--- a/src/controllers/NewsletterController.php
+++ b/src/controllers/NewsletterController.php
@@ -7,11 +7,6 @@ use juban\newsletter\models\NewsletterForm;
 use yii\web\BadRequestHttpException;
 use yii\web\Response;
 
-/**
- * NewsletterController class
- *
- * @author juban
- **/
 class NewsletterController extends Controller
 {
     protected array|int|bool $allowAnonymous = true;

--- a/src/controllers/NewsletterController.php
+++ b/src/controllers/NewsletterController.php
@@ -22,8 +22,8 @@ class NewsletterController extends Controller
         // form validation
         $newsletterForm = new NewsletterForm();
         $newsletterForm->email = $this->request->post('email');
-        $newsletterForm->consent = $this->request->post('consent');
-        $newsletterForm->additionalFields = $this->request->post('additionalFields');
+        $newsletterForm->consent = $this->request->post('consent', false);
+        $newsletterForm->additionalFields = $this->request->post('additionalFields', []);
 
         // Subscribe failed, send the form back
         if (!$newsletterForm->subscribe()) {

--- a/src/controllers/NewsletterController.php
+++ b/src/controllers/NewsletterController.php
@@ -4,7 +4,7 @@ namespace juban\newsletter\controllers;
 
 use craft\web\Controller;
 use juban\newsletter\models\NewsletterForm;
-use yii\web\BadRequestHttpException;
+use yii\web\MethodNotAllowedHttpException;
 use yii\web\Response;
 
 class NewsletterController extends Controller
@@ -13,7 +13,7 @@ class NewsletterController extends Controller
 
     /**
      * @return Response|null
-     * @throws BadRequestHttpException
+     * @throws MethodNotAllowedHttpException
      */
     public function actionSubscribe(): ?Response
     {
@@ -40,7 +40,6 @@ class NewsletterController extends Controller
         // Subscribe was successful
         return $this->asModelSuccess(
             $newsletterForm,
-            null,
             data: [
                 'success' => true,
             ]

--- a/src/events/SubscribeEvent.php
+++ b/src/events/SubscribeEvent.php
@@ -7,5 +7,6 @@ use craft\events\ModelEvent;
 class SubscribeEvent extends ModelEvent
 {
     public bool $isSpam = false;
+
     public bool $isNew = true;
 }

--- a/src/events/SubscribeEvent.php
+++ b/src/events/SubscribeEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace juban\newsletter\events;
+
+use craft\events\ModelEvent;
+
+class SubscribeEvent extends ModelEvent
+{
+    public bool $isSpam = false;
+    public bool $isNew = true;
+}

--- a/src/models/LocalizedSettingsCollection.php
+++ b/src/models/LocalizedSettingsCollection.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace juban\newsletter\models;
+
+use Craft;
+use craft\base\Model;
+
+class LocalizedSettingsCollection extends Model
+{
+    /** @var array<string, Settings> */
+    public array $localizedSettings = [];
+
+    /**
+     * Override setAttributes to capture dynamic site settings
+     */
+    public function setAttributes($values, $safeOnly = true): void
+    {
+        if (array_key_exists('localizedSettings', $values)) {
+            // Current settings schema
+
+            foreach ($values['localizedSettings'] as $siteHandle => $settingsArray) {
+                if (!Craft::$app->getSites()->getSiteByHandle($siteHandle)) {
+                    throw new \InvalidArgumentException("Site \"$siteHandle\" does not exist.");
+                }
+
+                if (array_key_exists('adapterTypeSettings', $settingsArray)) {
+                    // Populating the settings object from project config
+                    $this->localizedSettings[$siteHandle] = new Settings($settingsArray);
+                } else {
+                    // Normalizing a settings form before saving it
+
+                    $siteSettings = new Settings();
+                    $declaredSettingsNames = get_object_vars($siteSettings);
+
+                    $settingsArray = [
+                        'adapterTypeSettings' => $settingsArray[$settingsArray['adapterType']],
+                        ...array_intersect_key($settingsArray, $declaredSettingsNames),
+                    ];
+
+                    $siteSettings->setAttributes($settingsArray, false);
+                    $this->localizedSettings[$siteHandle] = $siteSettings;
+                }
+            }
+            return;
+        }
+
+
+        if (array_intersect(array_keys($values), ['adapterType', 'adapterSettings', 'recaptchaEnabled'])) {
+            // Legacy settings schema (non-localized)
+            $this->setAttributesFromNonLocalizedSettings($values);
+        }
+    }
+
+    private function setAttributesFromNonLocalizedSettings(array $values): void
+    {
+        foreach (Craft::$app->getSites()->getAllSites() as $site) {
+            $this->localizedSettings[$site->handle] = new Settings($values);
+        }
+    }
+
+    public function getSiteSettings(string $siteHandle): Settings
+    {
+        return $this->localizedSettings[$siteHandle] ?? new Settings();
+    }
+
+    public function defineRules(): array
+    {
+        return [
+            ['localizedSettings', 'validateEach'],
+        ];
+    }
+
+    public function validateEach($attribute): void
+    {
+        foreach ($this->$attribute as $siteHandle => $settingsModel) {
+            if (!$settingsModel->validate()) {
+                $this->addError($attribute, "Invalid settings for site '$siteHandle'.");
+            }
+        }
+    }
+}

--- a/src/models/LocalizedSettingsCollection.php
+++ b/src/models/LocalizedSettingsCollection.php
@@ -4,14 +4,20 @@ namespace juban\newsletter\models;
 
 use Craft;
 use craft\base\Model;
+use InvalidArgumentException;
 
+/**
+ * @property-write array $attributesFromNonLocalizedSettings
+ */
 class LocalizedSettingsCollection extends Model
 {
-    /** @var array<string, Settings|array> */
+    /** @var array<string, Settings|array<string, mixed>> */
     public array $localizedSettings = [];
 
     /**
      * Override setAttributes to capture dynamic site settings
+     * @inheritdoc
+     * @param array<string, mixed> $values
      */
     public function setAttributes($values, $safeOnly = true): void
     {
@@ -20,7 +26,7 @@ class LocalizedSettingsCollection extends Model
 
             foreach ($values['localizedSettings'] as $siteHandle => $settingsArray) {
                 if (!Craft::$app->getSites()->getSiteByHandle($siteHandle)) {
-                    throw new \InvalidArgumentException("Site \"$siteHandle\" does not exist.");
+                    throw new InvalidArgumentException("Site \"$siteHandle\" does not exist.");
                 }
 
                 if (array_key_exists('adapterTypeSettings', $settingsArray)) {
@@ -52,6 +58,9 @@ class LocalizedSettingsCollection extends Model
         }
     }
 
+    /**
+     * @param array<string, mixed> $values
+     */
     private function setAttributesFromNonLocalizedSettings(array $values): void
     {
         foreach (Craft::$app->getSites()->getAllSites() as $site) {
@@ -64,6 +73,11 @@ class LocalizedSettingsCollection extends Model
         return $this->localizedSettings[$siteHandle] ?? new Settings();
     }
 
+    /**
+     * @inheritdoc
+     * @return array<mixed>
+     * @noinspection PhpPluralMixedCanBeReplacedWithArrayInspection Yii rules are too polymorphic to be described easily
+     */
     protected function defineRules(): array
     {
         return [
@@ -71,7 +85,8 @@ class LocalizedSettingsCollection extends Model
         ];
     }
 
-    public function validateEach($attribute): void
+    /** @noinspection PhpUnused Used to validate the localizedSettings Yii attribute */
+    public function validateEach(string $attribute): void
     {
         foreach ($this->$attribute as $siteHandle => $settingsModel) {
             if (!$settingsModel->validate()) {

--- a/src/models/LocalizedSettingsCollection.php
+++ b/src/models/LocalizedSettingsCollection.php
@@ -7,7 +7,7 @@ use craft\base\Model;
 
 class LocalizedSettingsCollection extends Model
 {
-    /** @var array<string, Settings> */
+    /** @var array<string, Settings|array> */
     public array $localizedSettings = [];
 
     /**

--- a/src/models/LocalizedSettingsCollection.php
+++ b/src/models/LocalizedSettingsCollection.php
@@ -41,6 +41,7 @@ class LocalizedSettingsCollection extends Model
                     $this->localizedSettings[$siteHandle] = $siteSettings;
                 }
             }
+
             return;
         }
 
@@ -63,7 +64,7 @@ class LocalizedSettingsCollection extends Model
         return $this->localizedSettings[$siteHandle] ?? new Settings();
     }
 
-    public function defineRules(): array
+    protected function defineRules(): array
     {
         return [
             ['localizedSettings', 'validateEach'],

--- a/src/models/NewsletterForm.php
+++ b/src/models/NewsletterForm.php
@@ -5,6 +5,7 @@ namespace juban\newsletter\models;
 use Craft;
 use craft\base\Model;
 use juban\newsletter\Newsletter;
+use juban\newsletter\events\SubscribeEvent;
 
 /**
  * NewsletterForm class
@@ -18,6 +19,8 @@ class NewsletterForm extends Model
     public $consent;
 
     public $additionalFields;
+
+    public const EVENT_BEFORE_SUBSCRIBE = 'beforeSubscribe';
 
     public function rules(): array
     {
@@ -34,6 +37,14 @@ class NewsletterForm extends Model
     {
         if (!$this->validate()) {
             return false;
+        }
+
+        $event = new SubscribeEvent();
+        $this->trigger(self::EVENT_BEFORE_SUBSCRIBE, $event);
+
+        if ($event->isSpam) {
+            Craft::info("Spam submission detected ($this->email). Pretending subscription was successful without actually subscribing.", __METHOD__);
+            return true;
         }
 
         // Use newsletter module to register new user

--- a/src/models/NewsletterForm.php
+++ b/src/models/NewsletterForm.php
@@ -9,14 +9,20 @@ use juban\newsletter\events\SubscribeEvent;
 
 class NewsletterForm extends Model
 {
-    public $email;
+    public ?string $email = null;
 
-    public $consent;
+    public bool $consent = false;
 
-    public $additionalFields;
+    /** @var array<string, mixed> */
+    public array $additionalFields = [];
 
     public const EVENT_BEFORE_SUBSCRIBE = 'beforeSubscribe';
 
+    /**
+     * @inheritdoc
+     * @return array<mixed>
+     * @noinspection PhpPluralMixedCanBeReplacedWithArrayInspection Yii rules are too polymorphic to be described easily
+     */
     public function rules(): array
     {
         return [
@@ -43,9 +49,9 @@ class NewsletterForm extends Model
         }
 
         // Use newsletter module to register new user
-        $newsletterAdapater = Newsletter::$plugin->adapter;
-        if (!$newsletterAdapater->subscribe($this->email, $this->additionalFields)) {
-            $this->addError('email', $newsletterAdapater->getSubscriptionError());
+        $newsletterAdapter = Newsletter::$plugin->adapter;
+        if (!$newsletterAdapter->subscribe($this->email, $this->additionalFields)) {
+            $this->addError('email', $newsletterAdapter->getSubscriptionError());
             return false;
         }
 

--- a/src/models/NewsletterForm.php
+++ b/src/models/NewsletterForm.php
@@ -7,11 +7,6 @@ use craft\base\Model;
 use juban\newsletter\Newsletter;
 use juban\newsletter\events\SubscribeEvent;
 
-/**
- * NewsletterForm class
- *
- * @author juban
- **/
 class NewsletterForm extends Model
 {
     public $email;

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -7,11 +7,6 @@ use craft\base\Model;
 use craft\behaviors\EnvAttributeParserBehavior;
 use juban\newsletter\adapters\NewsletterAdapterInterface;
 
-/**
- * NewsletterSettings class
- *
- * @author juban
- **/
 class Settings extends Model
 {
     public $adapterType;

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -6,17 +6,21 @@ use Craft;
 use craft\base\Model;
 use craft\behaviors\EnvAttributeParserBehavior;
 use juban\newsletter\adapters\NewsletterAdapterInterface;
+use yii\base\Behavior;
 
 class Settings extends Model
 {
-    public $adapterType;
+    /** @var ?class-string<NewsletterAdapterInterface> */
+    public ?string $adapterType = null;
 
-    public $adapterTypeSettings = [];
+    /** @var array<string, mixed> */
+    public array $adapterTypeSettings = [];
 
-    public $recaptchaEnabled = true;
+    public bool $recaptchaEnabled = true;
 
     /**
      * @inheritdoc
+     * @return array<string, array{class: class-string}|class-string|Behavior>
      */
     public function behaviors(): array
     {
@@ -32,8 +36,9 @@ class Settings extends Model
 
     /**
      * @inheritdoc
+     * @return array<string, string>
      */
-    public function attributeLabels()
+    public function attributeLabels(): array
     {
         return [
             'adapterType' => Craft::t('newsletter', 'Service Type'),
@@ -42,8 +47,9 @@ class Settings extends Model
 
     /**
      * @inheritdoc
-     */
-    protected function defineRules(): array
+     * @return array<mixed>
+     * @noinspection PhpPluralMixedCanBeReplacedWithArrayInspection Yii rules are too polymorphic to be described easily
+     */    protected function defineRules(): array
     {
         $rules = parent::defineRules();
 
@@ -56,28 +62,31 @@ class Settings extends Model
 
     /**
      * Validates that adapterType is a valid class and extends Model.
+     * @noinspection PhpUnused Called when validating the adapterType Yii attribute.
      */
-    public function validateAdapterType($attribute, $params): void
+    public function validateAdapterType(string $attribute): void
     {
         if (!class_exists($this->$attribute)) {
-            $this->addError($attribute, "Class '{$this->$attribute}' does not exist.");
+            $this->addError($attribute, "Class '$attribute' does not exist.");
             return;
         }
 
         if (!is_subclass_of($this->$attribute, NewsletterAdapterInterface::class)) {
-            $this->addError($attribute, "Class '{$this->$attribute}' must implement " . NewsletterAdapterInterface::class);
+            $this->addError($attribute, "Class '$attribute' must implement " . NewsletterAdapterInterface::class);
         }
     }
 
     /**
      * Validates adapterTypeSettings against the instantiated adapterType model.
+     * @noinspection PhpUnused Called when validating the adapterTypeSettings Yii attribute.
      */
-    public function validateAdapterTypeSettings($attribute): void
+    public function validateAdapterTypeSettings(string $attribute): void
     {
         if (!$this->adapterType || !class_exists($this->adapterType)) {
             return;
         }
 
+        /** @var Model $adapterInstance */
         $adapterInstance = new $this->adapterType();
         $adapterInstance->setAttributes($this->$attribute, false);
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -5,6 +5,7 @@ namespace juban\newsletter\models;
 use Craft;
 use craft\base\Model;
 use craft\behaviors\EnvAttributeParserBehavior;
+use juban\newsletter\adapters\NewsletterAdapterInterface;
 
 /**
  * NewsletterSettings class
@@ -50,8 +51,47 @@ class Settings extends Model
     protected function defineRules(): array
     {
         $rules = parent::defineRules();
-        $rules[] = ['adapterType', 'required'];
+
+        $rules[] = [['adapterType'], 'required'];
+        $rules[] = [['adapterType'], 'validateAdapterType'];
+        $rules[] = [['adapterTypeSettings'], 'validateAdapterTypeSettings'];
 
         return $rules;
+    }
+
+    /**
+     * Validates that adapterType is a valid class and extends Model.
+     */
+    public function validateAdapterType($attribute, $params): void
+    {
+        if (!class_exists($this->$attribute)) {
+            $this->addError($attribute, "Class '{$this->$attribute}' does not exist.");
+            return;
+        }
+
+        if (!is_subclass_of($this->$attribute, NewsletterAdapterInterface::class)) {
+            $this->addError($attribute, "Class '{$this->$attribute}' must implement " . NewsletterAdapterInterface::class);
+        }
+    }
+
+    /**
+     * Validates adapterTypeSettings against the instantiated adapterType model.
+     */
+    public function validateAdapterTypeSettings($attribute): void
+    {
+        if (!$this->adapterType || !class_exists($this->adapterType)) {
+            return;
+        }
+
+        $adapterInstance = new $this->adapterType();
+        $adapterInstance->setAttributes($this->$attribute, false);
+
+        if (!$adapterInstance->validate()) {
+            foreach ($adapterInstance->getErrors() as $field => $messages) {
+                foreach ($messages as $message) {
+                    $this->addError("$attribute.$field", $message);
+                }
+            }
+        }
     }
 }

--- a/src/services/NewsletterAdapterService.php
+++ b/src/services/NewsletterAdapterService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace juban\newsletter\services;
+
+use craft\base\Component;
+use craft\helpers\Component as ComponentHelper;
+use juban\newsletter\adapters\NewsletterAdapterInterface;
+use juban\newsletter\Newsletter;
+
+class NewsletterAdapterService extends Component
+{
+    public function createAdapter(string $type, array $settings = null): NewsletterAdapterInterface
+    {
+        return ComponentHelper::createComponent([
+            'type' => $type,
+            'settings' => $settings,
+        ], NewsletterAdapterInterface::class);
+    }
+
+    public function getNewsletterAdapterForSite(string $siteHandle): NewsletterAdapterInterface
+    {
+        $settings = Newsletter::$plugin->getSettings()->getSiteSettings($siteHandle);
+        $adapterTypes = Newsletter::getAdaptersTypes();
+
+        // Backward compatibility with legacy adapters
+        if (str_starts_with($settings->adapterType, "simplonprod")) {
+            $settings->adapterType = str_replace('simplonprod', 'juban', $settings->adapterType);
+        }
+
+        if ($settings->adapterType === null) {
+            $settings->adapterType = $adapterTypes[0];
+            $settings->adapterTypeSettings = [];
+        }
+
+        return $this->createAdapter($settings->adapterType, $settings->adapterTypeSettings);
+    }
+}

--- a/src/services/NewsletterAdapterService.php
+++ b/src/services/NewsletterAdapterService.php
@@ -6,10 +6,15 @@ use craft\base\Component;
 use craft\helpers\Component as ComponentHelper;
 use juban\newsletter\adapters\NewsletterAdapterInterface;
 use juban\newsletter\Newsletter;
+use Throwable;
 
 class NewsletterAdapterService extends Component
 {
-    public function createAdapter(string $type, array $settings = null): NewsletterAdapterInterface
+    /**
+     * @param ?array<string, mixed> $settings
+     * @throws Throwable If creating the adapter instance fails.
+     */
+    public function createAdapter(string $type, ?array $settings = null): NewsletterAdapterInterface
     {
         return ComponentHelper::createComponent([
             'type' => $type,
@@ -17,6 +22,9 @@ class NewsletterAdapterService extends Component
         ], NewsletterAdapterInterface::class);
     }
 
+    /**
+     * @throws Throwable If creating the adapter instance fails.
+     */
     public function getNewsletterAdapterForSite(string $siteHandle): NewsletterAdapterInterface
     {
         $settings = Newsletter::$plugin->getSettings()->getSiteSettings($siteHandle);

--- a/src/templates/_layouts/settings.twig
+++ b/src/templates/_layouts/settings.twig
@@ -1,0 +1,30 @@
+{% requireAdmin %}
+
+{% extends "settings/plugins/_settings" %}
+
+{% if configPath %}
+    {% set errorSummary %}
+        <div class="readable">
+            <blockquote class="note warning">
+                <p>
+                    {{ 'It looks like these settings are being overridden by {paths}.'|t('app', {
+                        paths: configPath
+                    }) }}
+                </p>
+            </blockquote>
+        </div>
+        <br>
+    {% endset %}
+{% endif %}
+
+{% block content %}
+    {{ actionInput('plugins/save-plugin-settings') }}
+    {{ hiddenInput('pluginHandle', plugin.handle) }}
+    {{ redirectInput('settings') }}
+
+    {% for site in sites %}
+        <div id="{{ site.handle }}" {% if not loop.first %}class="hidden"{% endif %}>
+            {% include 'newsletter/site-settings.twig' %}
+        </div>
+    {% endfor %}
+{% endblock %}

--- a/src/templates/site-settings.twig
+++ b/src/templates/site-settings.twig
@@ -15,35 +15,31 @@
 
 {% import "_includes/forms" as forms %}
 
-{% if configPath %}
-    <div class="readable">
-        <blockquote class="note warning">
-            <p>
-                {{ 'It looks like these settings are being overridden by {paths}.'|t('app', {
-                    paths: configPath
-                }) }}
-            </p>
-        </blockquote>
-    </div>
-    <hr>
-{% endif %}
+{% set adapter = craft.newsletter.getNewsletterAdapterForSite(site.handle) %}
+{% do adapter.validate() %}
+{% set currentAdapterClassName = className(adapter) %}
+{% set namespace = "settings[localizedSettings][#{site.handle}]" %}
+{% set settings = settings.getSiteSettings(site.handle) %}
 
 {{ forms.selectField({
     label: "Service type"|t('newsletter'),
     instructions: "Which service should be use to handle newsletter users subscription?"|t('newsletter'),
     first: true,
-    id: 'adapterType',
-    name: 'adapterType',
+    id: "adapterType"|namespaceInputId(namespace),
+    name: "adapterType"|namespaceInputName(namespace),
     options: adapterTypeOptions,
-    value: className(adapter),
+    value: currentAdapterClassName,
     errors: adapter.getErrors('type') ?? null,
-    toggle: true
+    toggle: true,
+    targetPrefix: "##{namespace|id}-",
 }) }}
 
 {% for _adapter in allAdapters %}
-    {% set isCurrent = (className(_adapter) == className(adapter)) %}
-    <div id="{{ className(_adapter)|id }}"{% if not isCurrent %} class="hidden"{% endif %}>
-        {% namespace 'adapterSettings['~className(_adapter)~']' %}
+    {% set adapterClassName = className(_adapter) %}
+    {% set isCurrent = (adapterClassName == currentAdapterClassName) %}
+
+    <div id="{{ adapterClassName|id|namespaceInputId(namespace) }}"{% if not isCurrent %} class="hidden"{% endif %}>
+        {% namespace "#{namespace}[#{adapterClassName}]" %}
             {{ (isCurrent ? adapter : _adapter).getSettingsHtml()|raw }}
         {% endnamespace %}
     </div>
@@ -53,7 +49,7 @@
     {{ forms.booleanMenuField({
         label: "Enable Google reCAPTCHA"|t("newsletter"),
         instructions: "If enabled, newsletter subscription form will be verified using Google reCAPTCHA plugin."|t('newsletter'),
-        name: "recaptchaEnabled",
+        name: "recaptchaEnabled"|namespaceInputName(namespace),
         includeEnvVars: true,
         value: settings.recaptchaEnabled,
         errors: settings.errors("recaptchaEnabled")

--- a/src/variables/Newsletter.php
+++ b/src/variables/Newsletter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace juban\newsletter\variables;
+
+use juban\newsletter\adapters\NewsletterAdapterInterface;
+use juban\newsletter\Newsletter as NewsletterPlugin;
+
+class Newsletter
+{
+    public function getNewsletterAdapterForSite(string $siteHandle): NewsletterAdapterInterface
+    {
+        return NewsletterPlugin::$plugin->newsletterAdapterService->getNewsletterAdapterForSite($siteHandle);
+    }
+}

--- a/tests/unit/controllers/NewsletterTest.php
+++ b/tests/unit/controllers/NewsletterTest.php
@@ -116,8 +116,6 @@ class NewsletterTest extends BaseUnitTest
 
     protected function _before()
     {
-        parent::_before();
-
         $this->tester->mockMethods(
             Newsletter::$plugin,
             'adapter',


### PR DESCRIPTION
This PR make settings site-specific instead of being shared across all sites.

All settings can be adapted per-site even the adapter, which means a site can use Brevo while another one can use Mailchimp.

## Plugin settings schema changed

When upgrading the plugin, its settings schema isn't upgraded automatically. This means that the config/project.yaml won't change. However, when plugin settings are read, the global legacy settings are copied to all sites at runtime, allowing the plugin to work as expected. 

When the user saves the plugin settings, the schema will be upgraded.

The whole process should be totally transparent to the user.

## TODO

- I haven't found the time to update automated tests
- resolve TODOs and FIXMEs